### PR TITLE
#5068 Updated output format of time and data

### DIFF
--- a/manufacturers/Enginko/models/EGK/uplink_decoder.js
+++ b/manufacturers/Enginko/models/EGK/uplink_decoder.js
@@ -306,7 +306,7 @@ function ngsildWrapper(input, time) {
     input.forEach(item => {
         if(item.variable == 'date')
         {
-            time = item.value;
+            time = new Date(item.value);
         }
         if(item.variable == 'syncID')
         {
@@ -331,21 +331,21 @@ function ngsildWrapper(input, time) {
         }
         if(item.variable == 'temperature')
         {
-            temperature_data.push(ngsildInstance(item.value, 
+            temperature_data.push(ngsildInstance(parseFloat(item.value), 
                                                  time, 
                                                  'CEL', 
                                                  'Raw'));
         }
         if(item.variable == 'humidity')
         {
-            humidity_data.push(ngsildInstance(item.value, 
+            humidity_data.push(ngsildInstance(parseFloat(item.value), 
                                               time, 
                                               'P1', 
                                               'Raw'));
         }
         if(item.variable == 'pressure')
         {
-            pressure_data.push(ngsildInstance(item.value, 
+            pressure_data.push(ngsildInstance(parseFloat(item.value), 
                                               time, 
                                               'A97', 
                                               'Raw'));


### PR DESCRIPTION
Example of output for this payload `043546cb30bd0a723583013649cb30900a703f8301b64bcb306f0a7060830164`:

`{"temperature":[{"type":"Property","value":27.49,"observedAt":"2024-11-06T07:49:42.000Z","unitCode":"CEL","datasetId":"urn:ngsi-ld:Dataset:Raw"},{"type":"Property","value":27.04,"observedAt":"2024-11-06T08:09:44.000Z","unitCode":"CEL","datasetId":"urn:ngsi-ld:Dataset:Raw"},{"type":"Property","value":26.71,"observedAt":"2024-11-06T08:29:44.000Z","unitCode":"CEL","datasetId":"urn:ngsi-ld:Dataset:Raw"}],"humidity":[{"type":"Property","value":57,"observedAt":"2024-11-06T07:49:42.000Z","unitCode":"P1","datasetId":"urn:ngsi-ld:Dataset:Raw"},{"type":"Property","value":56,"observedAt":"2024-11-06T08:09:44.000Z","unitCode":"P1","datasetId":"urn:ngsi-ld:Dataset:Raw"},{"type":"Property","value":56,"observedAt":"2024-11-06T08:29:44.000Z","unitCode":"P1","datasetId":"urn:ngsi-ld:Dataset:Raw"}],"pressure":[{"type":"Property","value":991.25,"observedAt":"2024-11-06T07:49:42.000Z","unitCode":"A97","datasetId":"urn:ngsi-ld:Dataset:Raw"},{"type":"Property","value":991.35,"observedAt":"2024-11-06T08:09:44.000Z","unitCode":"A97","datasetId":"urn:ngsi-ld:Dataset:Raw"},{"type":"Property","value":991.68,"observedAt":"2024-11-06T08:29:44.000Z","unitCode":"A97","datasetId":"urn:ngsi-ld:Dataset:Raw"}]`